### PR TITLE
Added checking for null rendering hints

### DIFF
--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -8,23 +8,26 @@ import java.util.Map;
 
 public class MaterialDrawingUtils {
 
-	static {
-		System.setProperty ("awt.useSystemAAFontSettings", "on");
-		System.setProperty ("swing.aatext", "true");
-		System.setProperty ("sun.java2d.xrender", "true");
-	}
+    static {
+        System.setProperty("awt.useSystemAAFontSettings", "on");
+        System.setProperty("swing.aatext", "true");
+        System.setProperty("sun.java2d.xrender", "true");
+    }
 
-	public static Graphics getAliasedGraphics (Graphics g) {
-		Map<RenderingHints.Key, Object> hints = (Map<RenderingHints.Key, Object>) Toolkit.getDefaultToolkit ().getDesktopProperty ("awt.font.desktophints");
-
-		hints.put (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-		hints.put(RenderingHints.KEY_RENDERING,	RenderingHints.VALUE_RENDER_DEFAULT);
-		hints.put(RenderingHints.KEY_COLOR_RENDERING,	RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
-		hints.put(RenderingHints.KEY_TEXT_ANTIALIASING,	RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-
-		Graphics2D g2d = (Graphics2D) g;
-		g2d.addRenderingHints(hints);
-		//g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
-		return g2d;
-	}
+    public static Graphics getAliasedGraphics(Graphics g) {
+        Map<RenderingHints.Key, Object> hints = (Map<RenderingHints.Key, Object>) Toolkit.getDefaultToolkit()
+                .getDesktopProperty("awt.font.desktophints");
+        if (hints != null) {
+            hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
+            hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
+            hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+        }
+        Graphics2D g2d = (Graphics2D) g;
+        if (hints != null)
+            g2d.addRenderingHints(hints);
+        // g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING,
+        // RenderingHints.VALUE_ANTIALIAS_ON));
+        return g2d;
+    }
 }

--- a/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
+++ b/src/main/java/mdlaf/utils/MaterialDrawingUtils.java
@@ -15,19 +15,20 @@ public class MaterialDrawingUtils {
     }
 
     public static Graphics getAliasedGraphics(Graphics g) {
-        Map<RenderingHints.Key, Object> hints = (Map<RenderingHints.Key, Object>) Toolkit.getDefaultToolkit()
-                .getDesktopProperty("awt.font.desktophints");
-        if (hints != null) {
-            hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            hints.put(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
-            hints.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
-            hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-        }
-        Graphics2D g2d = (Graphics2D) g;
-        if (hints != null)
-            g2d.addRenderingHints(hints);
-        // g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING,
-        // RenderingHints.VALUE_ANTIALIAS_ON));
-        return g2d;
+        Map<RenderingHints.Key, Object> hints = (Map<RenderingHints.Key, Object>) Toolkit.getDefaultToolkit ().getDesktopProperty ("awt.font.desktophints");
+
+		if(hints != null){
+			hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			hints.put(RenderingHints.KEY_RENDERING,	RenderingHints.VALUE_RENDER_DEFAULT);
+			hints.put(RenderingHints.KEY_COLOR_RENDERING,	RenderingHints.VALUE_COLOR_RENDER_DEFAULT);
+			hints.put(RenderingHints.KEY_TEXT_ANTIALIASING,	RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+
+			Graphics2D g2d = (Graphics2D) g;
+			g2d.addRenderingHints(hints);
+			return g2d;
+		}
+		
+		//g2d.addRenderingHints (new RenderingHints (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON));
+		return g;
     }
 }


### PR DESCRIPTION
On some platforms the rendering hints map returned by `Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")` might be null, in which case, `NullPointerException`s will be thrown and no rendering will be done.