### PR TITLE
Fix issue where demo application does not terminate 

### DIFF
--- a/src/main/java/MaterialUISwingDemo.java
+++ b/src/main/java/MaterialUISwingDemo.java
@@ -328,7 +328,8 @@ public class MaterialUISwingDemo {
 		// make everything visible to the world
 		frame.pack ();
 		frame.setVisible (true);
-
+		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+		
 		JFileChooser fileChooser = new JFileChooser ();
 		fileChooser.showOpenDialog (frame);
 	}

--- a/src/main/java/mdlaf/components/button/MaterialButtonUI.java
+++ b/src/main/java/mdlaf/components/button/MaterialButtonUI.java
@@ -1,6 +1,5 @@
 package mdlaf.components.button;
 
-import javafx.scene.paint.Material;
 import mdlaf.animation.MaterialUIMovement;
 import mdlaf.utils.MaterialDrawingUtils;
 import mdlaf.utils.MaterialFontFactory;


### PR DESCRIPTION
I saw that old demo instances were running on my machine (Windows 10), even after closing the window.

This PR adds the default EXIT_ON_CLOSE to the MaterialUISwingDemo application, which ensure that the application shuts down correctly.